### PR TITLE
Cascader: fix input placeholder overlap with tags in multiple and filterable mode when global input background is transparent

### DIFF
--- a/packages/cascader/src/cascader.vue
+++ b/packages/cascader/src/cascader.vue
@@ -7,7 +7,7 @@
     @mouseleave="inputHover = false" @click="() => toggleDropDownVisible(readonly ? undefined : true)"
     @keydown="handleKeyDown">
 
-    <el-input ref="input" v-model="multiple ? presentText : inputValue" :size="realSize" :placeholder="placeholder"
+    <el-input ref="input" v-model="multiple ? presentText : inputValue" :size="realSize" :placeholder="multiple && filterable ? '' : placeholder"
       :readonly="readonly" :disabled="isDisabled" :validate-event="false" :class="{ 'is-focus': dropDownVisible }"
       @focus="handleFocus" @blur="handleBlur" @input="handleInput">
       <template slot="suffix">


### PR DESCRIPTION
By using conditional judgment to clear the placeholder in the multi-select searchable mode, the visual overlap problem with the selected tags is avoided.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

fixes #3 
